### PR TITLE
Fix/ci cache

### DIFF
--- a/.github/actions/create-requirements.yml
+++ b/.github/actions/create-requirements.yml
@@ -1,0 +1,43 @@
+name: create-requirements
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ master ]
+    paths:
+      - poetry.lock
+
+jobs:
+
+  create-reqs:
+    runs-on: ubuntu-latest
+    env:
+      TF_CPP_MIN_LOG_LEVEL: 3
+
+    steps:
+      - name: Setup Mambaforge
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          python-version: 3.9
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
+          activate-environment: qmlcourse.ai
+          environment-file: tools/environment.yml
+          use-mamba: true
+      - name: install the main dependencies
+        run: |
+          poetry install
+      # todo: replace with a more sane solution
+      - name: install tensorflow_quantum # https://www.tensorflow.org/quantum/install
+        run: |
+          poetry run pip install --upgrade pip
+          poetry run pip install -U tensorflow==2.5.1
+          poetry run pip install -U tensorflow_quantum
+          poetry run pip install -U tfq-nightly
+      - name: create requirements.yml
+        run: conda env export > environment.yml
+      - name: Upload output file
+        uses: actions/upload-artifact@v2
+        with:
+          name: environment-yml-file
+          path: environment.yml

--- a/.github/workflows/create-requirements.yml
+++ b/.github/workflows/create-requirements.yml
@@ -1,0 +1,44 @@
+name: create-requirements
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ master ]
+    paths:
+      - poetry.lock
+
+jobs:
+
+  create-reqs:
+    runs-on: ubuntu-latest
+    env:
+      TF_CPP_MIN_LOG_LEVEL: 3
+
+    steps:
+      - name: Setup Mambaforge
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          python-version: 3.9
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
+          activate-environment: qmlcourse.ai
+          environment-file: tools/environment.yml
+          use-mamba: true
+      - name: install the main dependencies
+        run: |
+          poetry install
+      # todo: replace with a more sane solution
+      - name: install tensorflow_quantum # https://www.tensorflow.org/quantum/install
+        run: |
+          poetry run pip install --upgrade pip
+          poetry run pip install -U tensorflow==2.5.1
+          poetry run pip install -U tensorflow_quantum
+          poetry run pip install -U tfq-nightly
+      - name: create requirements.yml
+        run: conda env export > environment.yml
+      - name: Upload output file
+        uses: actions/upload-artifact@v2
+        with:
+          name: environment-yml-file
+          path: environment.yml
+      # TODO: commit this file

--- a/.github/workflows/new-deploy-book.yml
+++ b/.github/workflows/new-deploy-book.yml
@@ -1,0 +1,100 @@
+name: new-deploy-book
+
+on:
+  workflow_dispatch:
+    inputs:
+      DisableCache:
+        description: 'Disable cache'
+        required: false
+        default: 'false'
+  push:
+    branches: [ master ]
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            label: linux-64
+            prefix: /usr/share/miniconda3/envs/qmlcourse.ai
+
+          # - os: macos-latest
+          #   label: osx-64
+          #   prefix: /Users/runner/miniconda3/envs/qmlcourse.ai
+
+          # - os: windows-latest
+          #   label: win-64
+          #   prefix: C:\Miniconda3\envs\qmlcourse.ai
+jobs:
+
+  deploy_book:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      TF_CPP_MIN_LOG_LEVEL: 3
+    steps:
+      - name: Checkout branch for build
+        uses: actions/checkout@v2
+
+      - name: Checkout branch with cache
+        uses: actions/checkout@v2
+        with:
+          ref: "gh-pages"
+          path: ./gh-pages
+
+      - name: Copy cache for build book
+        if: ${{ github.event.inputs.DisableCache != 'true' }}
+        run: |
+          cp -r ./gh-pages/_build/ ./qmlcourseRU/ || exit 0
+      - name: Download a requirements.yml artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: requirements-yml-file
+
+      # Install dependencies
+      - name: install qmlcourse.ai mamba env
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+            miniforge-variant: Mambaforge
+            miniforge-version: latest
+            use-mamba: true
+            python-version: 3.9
+            mamba-version: "*"
+            channels: conda-forge, defaults
+            channel-priority: true
+            activate-environment: qmlcourse.ai
+            environment-file: environment.yml
+
+      # Use cache
+      - uses: actions/cache@v2
+        with:
+          path: ${{ matrix.prefix }}
+          key: ${{ matrix.label }}-conda-${{ hashFiles('environment.yml') }}
+        id: mamba-cache
+
+      - name: export some tokens
+        env:
+          DWAVE_TOKEN: ${{ secrets.DWAVE_TOKEN }}
+        run: |
+          export DWAVE_TOKEN="$DWAVE_TOKEN"
+
+      - name: Build the book
+        run: |
+          poetry run jupyter-book build ./qmlcourseRU
+
+      # Push the book's HTML to github-pages
+      - name: GitHub Pages action
+        uses: peaceiris/actions-gh-pages@v3.8.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./qmlcourseRU
+
+#       - name: Build PDF file
+#         run: |
+#           poetry run jupyter-book build ./qmlcourseRU --builder pdfhtml
+#           mv ./qmlcourseRU/_build/pdf/book.pdf ./qmlcourseRU/_build/pdf/all_book.pdf
+
+#       - name: Deploy only pdf files
+#         uses: peaceiris/actions-gh-pages@v3
+#         with:
+#           github_token: ${{ secrets.GITHUB_TOKEN }}
+#           publish_dir: ./qmlcourseRU/_build/pdf/
+#           destination_dir: pdf

--- a/.github/workflows/new-deploy-branch.yml
+++ b/.github/workflows/new-deploy-branch.yml
@@ -1,0 +1,60 @@
+name: deploy-branch
+
+on:
+  workflow_dispatch:
+
+jobs:
+
+  deploy_branch:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v2
+
+      - name: get branch name
+        uses: nelonoel/branch-name@v1.0.1
+
+      - name: install mamba and poetry
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          python-version: 3.9
+          mamba-version: "*"
+          channels: conda-forge, psi4, defaults
+          channel-priority: true
+          activate-environment: qmlcourse.ai
+          environment-file: tools/environment.yml
+
+      - name: install poetry dependencies
+      - shell: bash -l {0}
+        run: poetry install
+
+      # todo: replace with a more sane solution
+      - name: install tensorflow_quantum
+      - shell: bash -l {0}
+        run: |
+          poetry run pip install -U tensorflow==2.5.1
+          poetry run pip install -U tensorflow_quantum
+          poetry run pip install -U tfq-nightly
+
+      - name: add SSH key-file
+        run: |
+          mkdir -p /home/runner/.ssh
+          echo "${{ secrets.AWS_SSH_KEY }}" > /home/runner/.ssh/key.pem
+          chmod 600 /home/runner/.ssh/key.pem
+
+      - name: build the book
+        run: |
+          export DWAVE_TOKEN="${{ secrets.DWAVE_TOKEN }}"
+          poetry run jupyter-book build ./qmlcourseRU
+
+      - name: deploy
+        run: |
+          export CURRENT_BRANCH="${BRANCH_NAME}"
+
+          export AWS_HOST="54.89.156.216"
+          export AWS_USER="ubuntu"
+          export SSH_KEY="/home/runner/.ssh/key.pem"
+
+          poetry run python ./tools/deploy2aws.py ./


### PR DESCRIPTION
Я все-таки вижу так, что нужно создавать requirements.yml для анаконды (сделано, но не протестировано в create-requirements.yml) и в деплое использовать ее. Единственное, что пока не сделал, это нужно create-requirements.yml перенести в экшены и добавить в деплое проверку, поменялся ли poetry.lock и pyproject.toml, если поменялись, то запускать этот экшен.

Не тестировал, не работал с gh-actions, так что если кто-то может помочь, было бы неплохо.
Вот тут дока, как делать кэш для миниконды https://github.com/marketplace/actions/setup-miniconda#caching

Критически важно ставить poetry из анакоды, типа conda install poetry, тогда не нужны все эти экшены, которые не очень понятно, как работают, изначально poetry будет ставить все в активированный environment, а эти пакеты будут при conda export идти как будто они из PYPI установлены.
