### PR TITLE
Silence netket 3.3 warning

### DIFF
--- a/qmlcourseRU/book/problems2qml/eigenvals.md
+++ b/qmlcourseRU/book/problems2qml/eigenvals.md
@@ -246,10 +246,10 @@ exact = nk.exact.lanczos_ed(op)[0]
 
 ```{code-cell} ipython3
 sampler = nk.sampler.MetropolisLocal(hi)
-model = nk.models.Jastrow()
+model = nk.models.Jastrow(dtype=complex)
 optimizer = nk.optimizer.Sgd(learning_rate=0.05)
 sr = nk.optimizer.SR(diag_shift=0.01)
-vmc = nk.driver.VMC(op, optimizer, sampler, model, n_samples=1000, preconditioner=sr)
+vmc = nk.driver.VMC(op, optimizer, sampler, model, n_samples=1008, preconditioner=sr)
 ```
 
 ```{note}


### PR DESCRIPTION
NetKet 3.3 now spits out a very innocuous warning when you set the number of samples to something that is not a multiple of the number of chains. 

```python
/home/filippovicentini/Dropbox/Ricerca/Codes/Python/netket/netket/vqs/mc/mc_state/state.py:58: UserWarning: n_samples=1000 (1000 per MPI rank) does not divide n_chains=16, increased to 1008 (1008 per MPI rank)
```

The logic is the same as before, we simply warn users that this is happening.
If you don't spceify the number of samples we'll pick the nearest multiple near 1000.
Since this looks like a book, I think it's nicer if users are not annoyed straight away.

I also took explicitly specify the dtype of Jastrow: if you use complex numbers you can describe signs and phases.
I don't speak russian, but in general we always try to stress that if you chose real parameters for your network you can only encode positive-valued states. It's a common source of questions in my experience.